### PR TITLE
v2 rewrite - labels and full filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # gmailfilters
 
-[![make-all](https://github.com/jessfraz/gmailfilters/workflows/make%20all/badge.svg)](https://github.com/jessfraz/gmailfilters/actions?query=workflow%3A%22make+all%22)
-[![make-image](https://github.com/jessfraz/gmailfilters/workflows/make%20image/badge.svg)](https://github.com/jessfraz/gmailfilters/actions?query=workflow%3A%22make+image%22)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](https://godoc.org/github.com/jessfraz/gmailfilters)
-[![Github All Releases](https://img.shields.io/github/downloads/jessfraz/gmailfilters/total.svg?style=for-the-badge)](https://github.com/jessfraz/gmailfilters/releases)
-
 A tool to sync Gmail filters from a config file to your account.
 
 > **NOTE:** This makes it so the single configuration file is the only way to
@@ -49,99 +44,98 @@ Usage: gmailfilters <command>
 
 Flags:
 
-  -d, --debug       enable debug logging (default: false)
-  -e, --export      export existing filters (default: false)
-  -f, --creds-file  Gmail credential file (or env var GMAIL_CREDENTIAL_FILE) (default: <none>)
-  -t, --token-file  Gmail oauth token file (default: /tmp/token.json)
+  --creds-file    Gmail credential file (or env var GMAIL_CREDENTIAL_FILE) (default: <none>)
+  -d, --debug     enable debug logging (default: false)
+  -e, --export    export existing filters (default: false)
+  --filters-file  Filters file (or env GMAIL_FILTERS_FILE) (default: <none>)
+  --labels-file   Labels file (or env GMAIL_LABELS_FILE) (default: <none>)
+  --token-file    Gmail oauth token file (default: /tmp/token.json)
 
 Commands:
 
   version  Show the version information.
 ```
 
+To start with, export your existing Gmail filters using the `--export` option.
+
 ## Example Filter File
 
 ```toml
-[[filter]]
-query = "to:your_activity@noreply.github.com"
-archive = true
-read = true
+[[Filter]]
+[Filter.Criteria]
+Query = "list:\"*.librato.github.com>\""
+[Filter.Action]
+Label = "INBOX/github/librato"
+Archive = true
 
-[[filter]]
-query = "from:notifications@github.com LGTM"
-label = "github/LGTM"
+[[Filter]]
+[Filter.Criteria]
+Query = "list:(<cloud-computing.googlegroups.com>)"
+[Filter.Action]
+Label = "INBOX/cloud-computing"
+Archive = true
 
-[[filter]]
-query = """
-(-to:team_mention@noreply.github.com \
-(from:(notifications@github.com) AND (@jfrazelle OR @jessfraz OR to:mention@noreply.github.com OR to:author@noreply.github.com OR to:assign@noreply.github.com)))
-"""
-label = "github/mentions"
+[[Filter]]
+[Filter.Criteria]
+Query = "list:(ltrace-devel.lists.alioth.debian.org)"
+[Filter.Action]
+Label = "INBOX/ltrace-devel"
+Archive = true
 
-[[filter]]
-query = """
-to:team_mention@noreply.github.com \
--to:mention@noreply.github.com \
--to:author@noreply.github.com \
--to:assign@noreply.github.com
-"""
-label = "github/team-mention"
+[[Filter]]
+[Filter.Criteria]
+Query = "list:statsite.armon.github.com"
+[Filter.Action]
+Label = "Devel"
 
-[[filter]]
-query = """
-from:notifications@github.com \
--to:team_mention@noreply.github.com \
--to:mention@noreply.github.com \
--to:author@noreply.github.com \
--to:assign@noreply.github.com
-"""
-archive = true
+[[Filter]]
+[Filter.Criteria]
+Query = "listid:containers.lists.linux-foundation.org"
+[Filter.Action]
+Label = "INBOX/linux/conts"
+Archive = true
 
-[[filter]]
-query = "(from:me AND to:reply@reply.github.com)"
-label = "github/mentions"
 
-[[filter]]
-query = "(from:notifications@github.com)"
-label = "github"
+[[Filter]]
+[Filter.Criteria]
+From = "@world-comp.org"
+Subject = "Congress"
+[Filter.Action]
+Label = ""
+Delete = true
+```
 
-[[filter]]
-queryOr = [
-"to:plans@tripit.com",
-"to:receipts@concur.com",
-"to:plans@concur.com",
-"to:receipts@expensify.com"
-]
-delete = true
+### Example labels file
 
-[[filter]]
-queryOr = [
-"from:notifications@docker.com",
-"from:noreply@github.com",
-"from:builds@travis-ci.org"
-]
-label = "to-be-deleted"
+```toml
+[[Label]]
+Id = "Label_9"
+Name = "INBOX/apple/drivers"
+Type = "user"
 
-[[filter]]
-query = "drive-shares-noreply@google.com OR (subject:\"Invitation to comment\" AND from:me ) OR from:(*@docs.google.com)"
-label = "to-be-deleted"
+[[Label]]
+Id = "Label_10"
+Name = "INBOX/apple/kernel"
+Type = "user"
 
-[[filter]]
-query = "(from:(-me) {filename:vcs filename:ics} has:attachment) OR (subject:(\"invitation\" OR \"accepted\" OR \"tentatively accepted\" OR \"rejected\" OR \"updated\" OR \"canceled event\" OR \"declined\") when where calendar who organizer)"
-label = "to-be-deleted"
+[[Label]]
+Id = "Label_11"
+Name = "INBOX/apple/scitech"
+Type = "user"
 
-[[filter]]
-query = "list:coreos-dev@googlegroups.com"
-label = "Mailing Lists/coreos-dev"
-archiveUnlessToMe = true
+[[Label]]
+Id = "Label_14"
+Name = "INBOX/archimedes/bugs"
+Type = "user"
 
-[[filter]]
-queryOr = [
-"list:xdg-app@lists.freedesktop.org",
-"list:flatpak@lists.freedesktop.org"
-]
-label = "Mailing Lists/xdg-apps"
-archiveUnlessToMe = true
+[[Label]]
+Id = "Label_1234"
+Name = "STATSDAPP"
+BackgroundColor = "#f691b2"
+TextColor = "#994a64"
+LabelListVisibility = "show"
+MessageListVisibility = "show"
+Type = "user"
 ```
 
 ## Setup
@@ -155,3 +149,10 @@ archiveUnlessToMe = true
 
     Follow the instructions 
     [for step enabling the API here](https://developers.google.com/gmail/api/quickstart/go).
+
+2. With the credentials file saved to `creds.json`, run the following:
+```
+gmailfilters --creds-file creds.json --token-file token.json
+```
+3. Follow the URL prompt and permit the token access. Copy the provided token JSON string.
+4. Paste the token JSON back in the terminal, it should now be saved as `token.json`.

--- a/export.go
+++ b/export.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+func exportExisting(labelMap *labelMap, filtersFile string, labelsFile string) error {
+	fmt.Print("exporting existing filters and labels...\n")
+
+	filters, err := getExistingFilters(labelMap)
+	if err != nil {
+		return fmt.Errorf("error downloading existing filters: %v", err)
+	}
+
+	if err := writeFiltersToFile(filters, filtersFile); err != nil {
+		return err
+	}
+
+	if err := writeLabelsToFile(labelMap, labelsFile); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/labels.go
+++ b/labels.go
@@ -1,65 +1,265 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/gmail/v1"
 )
 
-type labelMap map[string]string
-
-func getLabelMap() (labelMap, error) {
-	// Get the labels for the user and map its name to its ID.
-	l, err := api.Users.Labels.List(gmailUser).Do()
-	if err != nil {
-		return nil, fmt.Errorf("listing labels failed: %v", err)
-	}
-
-	labels := labelMap{}
-	for _, label := range l.Labels {
-		labels[strings.ToLower(label.Name)] = label.Id
-	}
-
-	return labels, nil
+type labelFile struct {
+	Label []*label
 }
 
-func getLabelMapOnID() (labelMap, error) {
+type label struct {
+	Id              string
+	Name            string
+	BackgroundColor string `toml:",omitempty"`
+	TextColor       string `toml:",omitempty"`
+
+	// LabelListVisbility: hide, show, showifunread
+	LabelListVisibility string `toml:",omitempty"`
+
+	// MessageListVisbility: hide or show
+	MessageListVisibility string `toml:",omitempty"`
+
+	// system or user
+	Type string
+}
+
+type labelMap struct {
+	byName map[string]*label
+	byID   map[string]*label
+}
+
+// Compare is used for sorting and we sort on name only
+func (l *label) Compare(o *label) int {
+	return strings.Compare(l.Name, o.Name)
+}
+
+// Equals returns a deep comparison, fixing differences in default values
+func (l *label) Equals(o *label) bool {
+	fixed := *o
+
+	if l.MessageListVisibility == "show" && fixed.MessageListVisibility == "" {
+		fixed.MessageListVisibility = "show"
+	}
+
+	if l.LabelListVisibility == "show" && fixed.LabelListVisibility == "" {
+		fixed.LabelListVisibility = "show"
+	}
+
+	return *l == fixed
+}
+
+func (l *label) IsValid() bool {
+	if l.Id == "" || l.Name == "" {
+		return false
+	}
+
+	if l.LabelListVisibility != "" && l.LabelListVisibility != "hide" &&
+		l.LabelListVisibility != "show" && l.LabelListVisibility != "showifunread" {
+		return false
+	}
+
+	if l.MessageListVisibility != "" && l.MessageListVisibility != "hide" && l.MessageListVisibility != "show" {
+		return false
+	}
+
+	if l.Type != "user" && l.Type != "system" {
+		return false
+	}
+
+	// Both colors have to be specified
+	if (l.BackgroundColor != "" && l.TextColor == "") || (l.TextColor != "" && l.BackgroundColor == "") {
+		return false
+	}
+
+	return true
+}
+
+func (l *label) UpdateLabel() error {
+	updateLabel := &gmail.Label{
+		Id:                    l.Id,
+		MessageListVisibility: l.MessageListVisibility,
+		Name:                  l.Name,
+		Type:                  l.Type,
+		NullFields:            []string{},
+	}
+
+	if l.BackgroundColor != "" || l.TextColor != "" {
+		updateLabel.Color = &gmail.LabelColor{
+			BackgroundColor: l.BackgroundColor,
+			TextColor:       l.TextColor,
+		}
+	} else {
+		updateLabel.NullFields = append(updateLabel.NullFields, "Color")
+	}
+
+	switch l.LabelListVisibility {
+	case "hide":
+		updateLabel.LabelListVisibility = "labelHide"
+	case "show":
+		updateLabel.LabelListVisibility = "labelShow"
+	case "showifunread":
+		updateLabel.LabelListVisibility = "labelShowIfUnread"
+	}
+
+	fmt.Printf("Updating label: %s\n", updateLabel.Name)
+	_, err := api.Users.Labels.Patch(gmailUser, l.Id, updateLabel).Do()
+	if err != nil {
+		return fmt.Errorf("failed to update label %s: %v", l.Name, err)
+	}
+
+	return nil
+}
+
+func getLabelMap() (*labelMap, error) {
 	// Get the labels for the user and map its name to its ID.
-	l, err := api.Users.Labels.List(gmailUser).Do()
+	labelList, err := api.Users.Labels.List(gmailUser).Do()
 	if err != nil {
 		return nil, fmt.Errorf("listing labels failed: %v", err)
 	}
 
-	labels := labelMap{}
-	for _, label := range l.Labels {
-		labels[label.Id] = label.Name
+	labels := labelMap{
+		byName: make(map[string]*label, len(labelList.Labels)),
+		byID:   make(map[string]*label, len(labelList.Labels)),
+	}
+	for _, lbl := range labelList.Labels {
+		labels.Add(labelFromAPI(lbl))
 	}
 
-	return labels, nil
+	return &labels, nil
+}
+
+func (m *labelMap) Add(lbl *label) {
+	m.byName[strings.ToLower(lbl.Name)] = lbl
+	m.byID[lbl.Id] = lbl
+}
+
+func (m *labelMap) GetByName(name string) *label {
+	return m.byName[strings.ToLower(name)]
+}
+
+func (m *labelMap) GetByID(id string) *label {
+	return m.byID[id]
 }
 
 func (m *labelMap) createLabelIfDoesNotExist(name string) (string, error) {
-	// De reference the pointer so we can index.
-	labels := *m
-
 	// Try to find the label.
-	id, ok := labels[strings.ToLower(name)]
-	if ok {
+	l := m.GetByName(name)
+	if l != nil {
 		// We found the label.
-		return id, nil
+		return l.Id, nil
 	}
 
 	// Create the label if it does not exist.
-	label, err := api.Users.Labels.Create(gmailUser, &gmail.Label{Name: name}).Do()
+	lbl, err := api.Users.Labels.Create(gmailUser, &gmail.Label{Name: name}).Do()
 	if err != nil {
 		return "", fmt.Errorf("creating label %s failed: %v", name, err)
 	}
 	logrus.Infof("Created label: %s", name)
 
-	// Update our label map.
-	labels[strings.ToLower(name)] = label.Id
-	m = &labels
-	return label.Id, nil
+	m.Add(labelFromAPI(lbl))
+	return lbl.Id, nil
+}
+
+func labelFromAPI(lbl *gmail.Label) *label {
+	var l label
+
+	l.Name = lbl.Name
+	l.Id = lbl.Id
+	if lbl.Color != nil {
+		l.BackgroundColor = lbl.Color.BackgroundColor
+		l.TextColor = lbl.Color.TextColor
+	}
+
+	l.LabelListVisibility = strings.TrimPrefix(strings.ToLower(lbl.LabelListVisibility), "label")
+	l.MessageListVisibility = strings.ToLower(lbl.MessageListVisibility)
+
+	l.Type = lbl.Type
+
+	return &l
+}
+
+func writeLabelsToFile(labelMap *labelMap, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("error exporting labels: %v", err)
+	}
+
+	writer := bufio.NewWriter(file)
+	encoder := toml.NewEncoder(writer)
+	encoder.Indent = ""
+
+	lf := &labelFile{
+		Label: make([]*label, 0, len(labelMap.byName)),
+	}
+
+	// build sorted file
+	for _, v := range labelMap.byName {
+		lf.Label = append(lf.Label, v)
+	}
+
+	sort.SliceStable(lf.Label, func(i, j int) bool {
+		return lf.Label[i].Compare(lf.Label[j]) < 0
+	})
+
+	if err := encoder.Encode(lf); err != nil {
+		return fmt.Errorf("error writing file: %v, labels: %+v", err, lf)
+	}
+
+	fmt.Printf("Exported %d labels\n", len(lf.Label))
+
+	return nil
+}
+
+func decodeLabelsFile(file string) ([]*label, error) {
+	var lf labelFile
+	meta, err := toml.DecodeFile(file, &lf)
+	if err != nil {
+		return nil, fmt.Errorf("decoding labels toml failed: %v", err)
+	}
+
+	if len(meta.Undecoded()) > 0 {
+		return nil, fmt.Errorf("undecoded fields found: %v", meta.Undecoded())
+	}
+
+	for _, l := range lf.Label {
+		if !l.IsValid() {
+			return nil, fmt.Errorf("label %s is invalid", l.Name)
+		}
+	}
+
+	return lf.Label, nil
+}
+
+func updateLabels(labels *labelMap, localLabels []*label) error {
+	updated := 0
+	for _, l := range localLabels {
+		rl := labels.GetByID(l.Id)
+		if rl == nil {
+			fmt.Printf("Local label %s not found remotely, will remove\n", l.Name)
+			continue
+		}
+
+		if !rl.Equals(l) {
+			*rl = *l
+			if err := rl.UpdateLabel(); err != nil {
+				return err
+			}
+			updated++
+		}
+	}
+
+	if updated > 0 {
+		fmt.Printf("updated %d labels\n", updated)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This started as a small project but ended up in a large rewrite. A few of the major changes:

* Full filter Criteria and Action definition support based on Gmail API
* Removes the DSL for filter criteria, leaning on matching the gmail API more closely (not compatible with anything earlier)
* Adds label support allowing the customization of label colors
* More validation checking to prevent deleting existing filters before verifying local versions
* Checks if any fields didn't parse during toml parsing and rejects updates

Labels operate slightly differently. From an import (ie, applying local changes to Gmail), local label changes are merged with the remote labels and the changes are written out locally during an import. It's a two-way update process. This is required to sync new label IDs.

This means it's not possible to add a new label for a filter AND set custom properties for it in the same pass. You will need to:

1. Add new filter with new label name.
2. Run an import, this will write label file at completion.
3. Set properties for new label that was created.
4. Re-run import which will sync label changes.
